### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*.d.ts"
-      ]
-    }
   },
   "scripts": {
     "build": "rimraf dist && tsc",
@@ -57,5 +46,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "antelopeJs": {}
 }


### PR DESCRIPTION
## Summary
- Add `antelopeJs` field to package.json (empty object for consistency across interface-* repos)
- Remove wildcard subpath exports (`./*` and `typesVersions` wildcard) to hide internal dist paths from consumers

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the package's public API surface by removing the `./*` wildcard subpath export and the `typesVersions` wildcard, and adds an empty `antelopeJs` field for consistency with other `interface-*` packages. The changes are intentional and low-risk for a package whose consumers only use the root import, but removing the wildcard export is technically a breaking change if any consumer imported internal sub-paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only concern is a potential (non-confirmed) semver impact from removing wildcard exports.

All findings are P2. The only concern is speculative: whether any consumer actually uses sub-path imports. If the team is confident no consumers rely on `./*` paths, the change is clean and safe.

No files require special attention beyond the noted semver consideration in package.json.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard subpath exports and `typesVersions`, adds empty `antelopeJs` field — potentially a breaking change for any consumer importing sub-paths, with no version bump. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer imports package] --> B{Import path?}
    B -->|"@antelopejs/interface-mongodb"| C["✅ Resolves via '.' export\n(unchanged)"]
    B -->|"@antelopejs/interface-mongodb/package.json"| D["✅ Resolves via './package.json' export\n(unchanged)"]
    B -->|"@antelopejs/interface-mongodb/any-other-path"| E["❌ ERR_PACKAGE_PATH_NOT_EXPORTED\n(wildcard './*' removed by this PR)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package.json
Line: 23-26

Comment:
**Potentially breaking removal of wildcard subpath exports**

Dropping the `./*` export map entry and `typesVersions` wildcard prevents consumers from importing any sub-path other than the package root (e.g. `import x from '@antelopejs/interface-mongodb/some-module'` will now throw `ERR_PACKAGE_PATH_NOT_EXPORTED`). If any downstream code relies on these paths, this is a breaking change. The PR is labelled `chore` and the version remains `0.0.2`, so there is no semver signal to consumers that a breaking change was shipped. If sub-path imports were never intended to be part of the public API, a note in the changelog or a minor version bump would communicate the intent clearly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove wildcard exports and add a..."](https://github.com/antelopejs/interface-mongodb/commit/657aca41c055929316aa8335afdaecdf04576ff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29167110)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->