### PR TITLE
feat(skills): ship a consumer skill with the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "docs",
+    "skills"
   ],
   "exports": {
     ".": {
@@ -47,5 +49,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "antelopeJs": {}
+  "antelopeJs": {
+    "skills": ["./skills"]
+  }
 }

--- a/skills/mongodb-interface/SKILL.md
+++ b/skills/mongodb-interface/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: mongodb-interface
+description: Provides direct access to the shared MongoDB connection in an AntelopeJS app via a single GetClient() function that resolves to the raw mongodb driver MongoClient (full CRUD, aggregations, indexes, transactions). Use when code imports "@antelopejs/interface-mongodb", when you see GetClient or the internal.SetClient/UnsetClient namespace, or when a task asks to query/insert/update/aggregate MongoDB documents, access db()/collection(), or wire a MongoDB connection into an AntelopeJS module.
+category: antelopejs-interface
+tags: [mongodb, database, antelopejs, interface, driver]
+---
+
+# MongoDB Interface
+
+Thin interface over the official `mongodb` Node.js driver. It holds a singleton
+`Promise<MongoClient>`: a MongoDB provider module resolves it once connected, and
+consumer code awaits it via `GetClient()`. There are no proxy crossings, decorators,
+or query builders here — everything after `await GetClient()` is the plain driver API.
+
+## Imports
+
+```typescript
+import { GetClient } from "@antelopejs/interface-mongodb";
+```
+
+The package has a single entry point (`.` in the exports map). It also exports an
+`internal` namespace from the same path, which is for providers only (see below).
+Driver types such as `MongoClient`, `ObjectId`, and `Filter` come from the `mongodb`
+package, which is a regular dependency of this interface.
+
+## Consuming
+
+```typescript
+import { GetClient } from "@antelopejs/interface-mongodb";
+
+async function findUsersByRole(role: string) {
+  const client = await GetClient();
+  const users = client.db("myapp").collection("users");
+  return users.find({ role }).toArray();
+}
+```
+
+`GetClient()` returns a `Promise<MongoClient>` that resolves once a connection is
+established. From there, use the standard driver API: `db()`, `collection()`,
+`insertOne`, `find`, `aggregate`, `createIndex`, transactions, etc.
+
+## Providing
+
+A provider module (typically an AntelopeJS MongoDB module) owns the connection
+lifecycle through the `internal` namespace: it calls `internal.SetClient(client)`
+to resolve the pending promise when connected, sets `internal.connected`, and calls
+`internal.UnsetClient()` on disconnect to arm a fresh unresolved promise. Consumer
+code must never touch `internal`.
+
+## Gotchas
+
+- `GetClient()` only resolves after a provider module connects. Without a MongoDB
+  provider module loaded in the app, the promise stays pending forever — it does
+  not reject or time out.
+- Call `GetClient()` at the point of use rather than caching the client at module
+  load: on disconnect the provider swaps in a new promise via `internal.UnsetClient()`,
+  and a fresh `GetClient()` call picks up the next connection.
+- Never call `client.close()` from consumer code; the connection is a shared
+  singleton owned by the provider module.
+- This interface adds no abstraction over the driver — for query syntax and options,
+  rely on the official MongoDB Node.js driver documentation.
+
+## Deeper reference
+
+See this package's `docs/1.introduction.md` ("Interface MongoDB Documentation":
+Overview, Getting Started, GetClient, CRUD Operations, Aggregation Pipelines,
+Indexes) and the shipped `dist/index.d.ts` for the exact typed surface.

--- a/skills/mongodb-interface/SKILL.md
+++ b/skills/mongodb-interface/SKILL.md
@@ -28,10 +28,10 @@ package, which is a regular dependency of this interface.
 ```typescript
 import { GetClient } from "@antelopejs/interface-mongodb";
 
-async function findUsersByRole(role: string) {
+async function findBooksByGenre(genre: string) {
   const client = await GetClient();
-  const users = client.db("myapp").collection("users");
-  return users.find({ role }).toArray();
+  const books = client.db("library").collection("books");
+  return books.find({ genre }).toArray();
 }
 ```
 


### PR DESCRIPTION
## Summary
- Adds `skills/<name>-interface/SKILL.md`: a lean, source-grounded consumer guide (imports per subpath, minimal example, gotchas, pointer to the shipped `.d.ts`)
- Wires it for distribution: `antelopeJs.skills: ["./skills"]` + `skills` in the `files` array
- Consumers get it automatically: the antelopejs Claude Code plugin syncs package-shipped skills into `.claude/skills/`; the cms-ai chatbox loads them at runtime
- Content fact-checked against `src/`/`docs/` by an adversarial review pass (imports validated against the exports map, examples verified against real signatures)

## Test plan
N/A (documentation artifact; frontmatter and import paths validated mechanically)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships a consumer skill guide (`skills/mongodb-interface/SKILL.md`) alongside the package and wires it for distribution by adding `docs` and `skills` to the npm `files` array and registering the skills directory in `antelopeJs.skills`.

- **`SKILL.md`**: Documents `GetClient()`, the `internal` provider namespace (`SetClient`/`UnsetClient`/`connected`), key gotchas (pending-forever promise, don't cache the client, don't call `client.close()`), and pointers to `docs/1.introduction.md` and `dist/index.d.ts` — all cross-checked against `src/index.ts` and the existing docs.
- **`package.json`**: Adds `"docs"` and `"skills"` to `files`, and sets `"antelopeJs": { "skills": ["./skills"] }` so the AntelopeJS Claude Code plugin can sync the skill automatically.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive documentation and packaging changes with no logic modifications.

Every claim in SKILL.md was verified against `src/index.ts` and `docs/1.introduction.md`: exported symbols match, behavioural descriptions are accurate, and the docs/dist references are now valid because both directories are added to the npm `files` array in the same commit. No existing behaviour is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds `docs` and `skills` to the npm `files` array and registers `./skills` in the `antelopeJs` skills manifest — both changes are consistent with distributing the new SKILL.md and making docs reachable from the referenced skill path. |
| skills/mongodb-interface/SKILL.md | New consumer skill document; all imports, exported symbols (`GetClient`, `internal.SetClient`, `internal.UnsetClient`, `internal.connected`), behavioural gotchas, and the docs reference verified against `src/index.ts` and `docs/1.introduction.md`. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["npm publish<br/>(@antelopejs/interface-mongodb)"] --> B["Package contents<br/>dist/ + docs/ + skills/"]
    B --> C["AntelopeJS Claude Code plugin<br/>(syncs package skills)"]
    B --> D["cms-ai chatbox<br/>(loads skills at runtime)"]
    C --> E[".claude/skills/mongodb-interface/SKILL.md"]
    D --> F["AI assistant context:<br/>GetClient usage, gotchas, provider lifecycle"]
    E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["npm publish<br/>(@antelopejs/interface-mongodb)"] --> B["Package contents<br/>dist/ + docs/ + skills/"]
    B --> C["AntelopeJS Claude Code plugin<br/>(syncs package skills)"]
    B --> D["cms-ai chatbox<br/>(loads skills at runtime)"]
    C --> E[".claude/skills/mongodb-interface/SKILL.md"]
    D --> F["AI assistant context:<br/>GetClient usage, gotchas, provider lifecycle"]
    E --> F
```

</a>

<sub>Reviews (4): Last reviewed commit: ["docs(skills): use fictional domains in c..."](https://github.com/antelopejs/interface-mongodb/commit/84be301b927b2306cf04879ecf67d7e0848b67e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45477193)</sub>

<!-- /greptile_comment -->